### PR TITLE
Add seshcookie-js migration support with sc1_ wire format versioning

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"slices"
 	"strings"
 
 	"google.golang.org/protobuf/proto"
@@ -101,8 +102,7 @@ func decodeJSCookie(encoded string, jsEncKey []byte) ([]byte, error) {
 	// Go's aead.Open expects ciphertext with tag appended.
 	// JS separates them, so concatenate before decrypting.
 	// JS passes nonce as AAD via cipher.setAAD(nonce).
-	ciphertextWithTag := append(ciphertext, tag...)
-	plaintext, err := aeadCipher.Open(nil, nonce, ciphertextWithTag, nonce)
+	plaintext, err := aeadCipher.Open(nil, nonce, slices.Concat(ciphertext, tag), nonce)
 	if err != nil {
 		return nil, fmt.Errorf("aeadCipher.Open: %w", err)
 	}

--- a/migrate.go
+++ b/migrate.go
@@ -1,0 +1,134 @@
+// Copyright 2025 Bobby Powers. All rights reserved.
+// Use of this source code is governed by the MIT
+// license that can be found in the LICENSE file.
+
+package seshcookie
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// MigrateFunc converts raw JSON bytes from a seshcookie-js session
+// into the caller's protobuf session type. The JSON is the direct
+// plaintext that was stored in the JS cookie (i.e. JSON.stringify(session)).
+type MigrateFunc[T proto.Message] func(jsonData []byte) (T, error)
+
+// migrateConfig holds pre-computed state for JS cookie migration.
+type migrateConfig[T proto.Message] struct {
+	jsEncKey []byte
+	convert  MigrateFunc[T]
+}
+
+// Option configures optional Handler behavior.
+type Option[T proto.Message] func(*handlerOptions[T])
+
+// handlerOptions collects all optional configuration.
+type handlerOptions[T proto.Message] struct {
+	migrate *migrateConfig[T]
+}
+
+// WithMigration returns an Option that enables transparent migration
+// from seshcookie-js cookies. jsKey is the key string that was passed
+// to the JS seshcookie constructor. convert transforms the JSON session
+// payload into the caller's protobuf type.
+//
+// When a request arrives with a JS-format cookie (no "sc1_" prefix,
+// three base64 parts separated by hyphens), the handler decrypts it
+// using the JS key derivation (SHA256(key)[:16]) and passes the JSON
+// plaintext to convert. The resulting session is written back as a
+// Go-format cookie on the response, completing the migration.
+func WithMigration[T proto.Message](jsKey string, convert MigrateFunc[T]) Option[T] {
+	encKey := deriveJSKey(jsKey)
+	return func(o *handlerOptions[T]) {
+		o.migrate = &migrateConfig[T]{
+			jsEncKey: encKey,
+			convert:  convert,
+		}
+	}
+}
+
+// deriveJSKey replicates the seshcookie-js key derivation: SHA256(key)[:16].
+func deriveJSKey(key string) []byte {
+	h := sha256.Sum256([]byte(key))
+	return h[:16]
+}
+
+// decodeJSCookie decrypts a seshcookie-js cookie value and returns the
+// JSON plaintext. The JS wire format is "b64(nonce)-b64(ciphertext)-b64(tag)"
+// with the nonce passed as AAD.
+func decodeJSCookie(encoded string, jsEncKey []byte) ([]byte, error) {
+	parts := strings.Split(encoded, "-")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("expected 3 parts, got %d", len(parts))
+	}
+
+	nonce, err := base64.StdEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("decode nonce: %w", err)
+	}
+
+	ciphertext, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode ciphertext: %w", err)
+	}
+
+	tag, err := base64.StdEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("decode tag: %w", err)
+	}
+
+	if len(nonce) != gcmNonceSize {
+		return nil, fmt.Errorf("nonce length %d, want %d", len(nonce), gcmNonceSize)
+	}
+
+	block, err := aes.NewCipher(jsEncKey)
+	if err != nil {
+		return nil, fmt.Errorf("aes.NewCipher: %w", err)
+	}
+
+	aeadCipher, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("cipher.NewGCM: %w", err)
+	}
+
+	// Go's aead.Open expects ciphertext with tag appended.
+	// JS separates them, so concatenate before decrypting.
+	// JS passes nonce as AAD via cipher.setAAD(nonce).
+	ciphertextWithTag := append(ciphertext, tag...)
+	plaintext, err := aeadCipher.Open(nil, nonce, ciphertextWithTag, nonce)
+	if err != nil {
+		return nil, fmt.Errorf("aeadCipher.Open: %w", err)
+	}
+
+	return plaintext, nil
+}
+
+// decodeJSSession attempts to decrypt a JS-format cookie and convert
+// the JSON payload to the caller's protobuf session type. Returns the
+// zero value of T and an error on failure.
+func (h *Handler[T]) decodeJSSession(cookieValue string) (T, error) {
+	var zero T
+
+	if h.opts.migrate == nil {
+		return zero, fmt.Errorf("no migration configured")
+	}
+
+	jsonData, err := decodeJSCookie(cookieValue, h.opts.migrate.jsEncKey)
+	if err != nil {
+		return zero, fmt.Errorf("decodeJSCookie: %w", err)
+	}
+
+	session, err := h.opts.migrate.convert(jsonData)
+	if err != nil {
+		return zero, fmt.Errorf("convert: %w", err)
+	}
+
+	return session, nil
+}

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -374,6 +374,56 @@ func TestMigrationConvertError(t *testing.T) {
 	}
 }
 
+func TestMigrationGarbageInput(t *testing.T) {
+	goKey := createKeyString()
+
+	config := &Config{
+		CookieName: testCookieName,
+		HTTPOnly:   true,
+		Secure:     false,
+		MaxAge:     24 * time.Hour,
+	}
+
+	convert := func(jsonData []byte) (*pb.TestSession, error) {
+		return &pb.TestSession{Count: 1}, nil
+	}
+
+	mw, err := NewMiddleware[*pb.TestSession](goKey, config,
+		WithMigration[*pb.TestSession]("some-js-key", convert))
+	if err != nil {
+		t.Fatalf("NewMiddleware: %v", err)
+	}
+
+	handler := mw(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		session, err := GetSession[*pb.TestSession](req.Context())
+		if err != nil {
+			http.Error(rw, err.Error(), 500)
+			return
+		}
+		rw.WriteHeader(200)
+		fmt.Fprintf(rw, "count=%d", session.Count)
+	}))
+
+	// Cookie that looks like JS format (3 hyphen-separated parts) but is garbage
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: testCookieName, Value: "AAAA-BBBB-CCCC"})
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Should get empty session since decryption fails on garbage
+	if string(body) != "count=0" {
+		t.Fatalf("body = %q, want %q (empty session for garbage input)", string(body), "count=0")
+	}
+}
+
 func TestNoMigrationIgnoresJSCookies(t *testing.T) {
 	vectors := loadVectors(t)
 	vec := vectors[0]

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -1,0 +1,423 @@
+// Copyright 2025 Bobby Powers. All rights reserved.
+// Use of this source code is governed by the MIT
+// license that can be found in the LICENSE file.
+
+package seshcookie
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bpowers/seshcookie/v3/internal/pb"
+)
+
+type jsVector struct {
+	Description   string `json:"description"`
+	Key           string `json:"key"`
+	DerivedKeyHex string `json:"derived_key_hex"`
+	SessionJSON   string `json:"session_json"`
+	CookieValue   string `json:"cookie_value"`
+}
+
+type jsVectors struct {
+	Vectors []jsVector `json:"vectors"`
+}
+
+func loadVectors(t *testing.T) []jsVector {
+	t.Helper()
+	data, err := os.ReadFile("testdata/js_vectors.json")
+	if err != nil {
+		t.Fatalf("read test vectors: %v", err)
+	}
+	var vecs jsVectors
+	if err := json.Unmarshal(data, &vecs); err != nil {
+		t.Fatalf("unmarshal test vectors: %v", err)
+	}
+	return vecs.Vectors
+}
+
+func TestDeriveJSKey(t *testing.T) {
+	vectors := loadVectors(t)
+	for _, v := range vectors {
+		t.Run(v.Description, func(t *testing.T) {
+			got := deriveJSKey(v.Key)
+			gotHex := hex.EncodeToString(got)
+			if gotHex != v.DerivedKeyHex {
+				t.Errorf("deriveJSKey(%q) = %s, want %s", v.Key, gotHex, v.DerivedKeyHex)
+			}
+		})
+	}
+}
+
+func TestDecodeJSCookie(t *testing.T) {
+	vectors := loadVectors(t)
+	for _, v := range vectors {
+		t.Run(v.Description, func(t *testing.T) {
+			encKey := deriveJSKey(v.Key)
+			plaintext, err := decodeJSCookie(v.CookieValue, encKey)
+			if err != nil {
+				t.Fatalf("decodeJSCookie: %v", err)
+			}
+			if string(plaintext) != v.SessionJSON {
+				t.Errorf("plaintext = %q, want %q", string(plaintext), v.SessionJSON)
+			}
+		})
+	}
+}
+
+func TestDecodeJSCookieMalformed(t *testing.T) {
+	validKey := deriveJSKey("test-secret-key")
+
+	t.Run("wrong part count - too few", func(t *testing.T) {
+		_, err := decodeJSCookie("abc-def", validKey)
+		if err == nil {
+			t.Error("expected error for 2-part cookie")
+		}
+	})
+
+	t.Run("wrong part count - too many", func(t *testing.T) {
+		_, err := decodeJSCookie("a-b-c-d", validKey)
+		if err == nil {
+			t.Error("expected error for 4-part cookie")
+		}
+	})
+
+	t.Run("bad base64 nonce", func(t *testing.T) {
+		_, err := decodeJSCookie("!!!-AAAA-AAAA", validKey)
+		if err == nil {
+			t.Error("expected error for bad base64 nonce")
+		}
+	})
+
+	t.Run("bad base64 ciphertext", func(t *testing.T) {
+		_, err := decodeJSCookie("AAAAAAAAAAAAAAAA-!!!-AAAA", validKey)
+		if err == nil {
+			t.Error("expected error for bad base64 ciphertext")
+		}
+	})
+
+	t.Run("bad base64 tag", func(t *testing.T) {
+		_, err := decodeJSCookie("AAAAAAAAAAAAAAAA-AAAA-!!!", validKey)
+		if err == nil {
+			t.Error("expected error for bad base64 tag")
+		}
+	})
+
+	t.Run("wrong key", func(t *testing.T) {
+		vectors := loadVectors(t)
+		wrongKey := deriveJSKey("wrong-key")
+		_, err := decodeJSCookie(vectors[0].CookieValue, wrongKey)
+		if err == nil {
+			t.Error("expected error decrypting with wrong key")
+		}
+	})
+
+	t.Run("tampered ciphertext", func(t *testing.T) {
+		vectors := loadVectors(t)
+		parts := strings.Split(vectors[0].CookieValue, "-")
+		// flip a byte in the ciphertext
+		ct := []byte(parts[1])
+		ct[0] ^= 0xff
+		parts[1] = string(ct)
+		tampered := strings.Join(parts, "-")
+
+		_, err := decodeJSCookie(tampered, validKey)
+		if err == nil {
+			t.Error("expected error for tampered ciphertext")
+		}
+	})
+
+	t.Run("tampered tag", func(t *testing.T) {
+		vectors := loadVectors(t)
+		parts := strings.Split(vectors[0].CookieValue, "-")
+		// flip a byte in the tag
+		tag := []byte(parts[2])
+		tag[0] ^= 0xff
+		parts[2] = string(tag)
+		tampered := strings.Join(parts, "-")
+
+		_, err := decodeJSCookie(tampered, validKey)
+		if err == nil {
+			t.Error("expected error for tampered tag")
+		}
+	})
+}
+
+func TestMigrationEndToEnd(t *testing.T) {
+	vectors := loadVectors(t)
+	vec := vectors[0] // simple session: {count: 42, user: "alice"}
+
+	goKey := createKeyString()
+	jsKey := vec.Key
+
+	config := &Config{
+		CookieName: testCookieName,
+		HTTPOnly:   true,
+		Secure:     false,
+		MaxAge:     24 * time.Hour,
+	}
+
+	convert := func(jsonData []byte) (*pb.TestSession, error) {
+		var raw map[string]any
+		if err := json.Unmarshal(jsonData, &raw); err != nil {
+			return nil, err
+		}
+		session := &pb.TestSession{}
+		if v, ok := raw["count"].(float64); ok {
+			session.Count = int32(v)
+		}
+		if v, ok := raw["user"].(string); ok {
+			session.User = v
+		}
+		return session, nil
+	}
+
+	mw, err := NewMiddleware[*pb.TestSession](goKey, config,
+		WithMigration[*pb.TestSession](jsKey, convert))
+	if err != nil {
+		t.Fatalf("NewMiddleware: %v", err)
+	}
+
+	// Handler that reads and reports the session
+	readHandler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		session, err := GetSession[*pb.TestSession](req.Context())
+		if err != nil {
+			http.Error(rw, err.Error(), 500)
+			return
+		}
+		rw.WriteHeader(200)
+		fmt.Fprintf(rw, "count=%d user=%s", session.Count, session.User)
+	})
+
+	handler := mw(readHandler)
+
+	// First request: send JS cookie
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: testCookieName, Value: vec.CookieValue})
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	if string(body) != "count=42 user=alice" {
+		t.Fatalf("body = %q, want %q", string(body), "count=42 user=alice")
+	}
+
+	// Should have a Set-Cookie with sc1_ prefix (Go format)
+	cookies := resp.Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 cookie, got %d", len(cookies))
+	}
+
+	goCookie := cookies[0]
+	if !strings.HasPrefix(goCookie.Value, versionPrefix) {
+		t.Fatalf("cookie value %q does not have sc1_ prefix", goCookie.Value)
+	}
+
+	// Second request: send Go cookie back
+	req = httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(goCookie)
+	w = httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	resp = w.Result()
+	body, _ = io.ReadAll(resp.Body)
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	if string(body) != "count=42 user=alice" {
+		t.Fatalf("body = %q after re-read, want %q", string(body), "count=42 user=alice")
+	}
+
+	// Session unchanged, no new cookie should be set
+	if len(resp.Cookies()) != 0 {
+		t.Fatalf("expected no cookie on unchanged re-read, got %d", len(resp.Cookies()))
+	}
+}
+
+func TestMigrationWithDifferentKeys(t *testing.T) {
+	vectors := loadVectors(t)
+	vec := vectors[1] // single string field with "another-key-here"
+
+	// Go key is different from JS key
+	goKey := createKeyString()
+	jsKey := vec.Key
+
+	config := &Config{
+		CookieName: testCookieName,
+		HTTPOnly:   true,
+		Secure:     false,
+		MaxAge:     24 * time.Hour,
+	}
+
+	convert := func(jsonData []byte) (*pb.TestSession, error) {
+		var raw map[string]any
+		if err := json.Unmarshal(jsonData, &raw); err != nil {
+			return nil, err
+		}
+		session := &pb.TestSession{}
+		if v, ok := raw["name"].(string); ok {
+			session.User = v
+		}
+		return session, nil
+	}
+
+	mw, err := NewMiddleware[*pb.TestSession](goKey, config,
+		WithMigration[*pb.TestSession](jsKey, convert))
+	if err != nil {
+		t.Fatalf("NewMiddleware: %v", err)
+	}
+
+	handler := mw(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		session, err := GetSession[*pb.TestSession](req.Context())
+		if err != nil {
+			http.Error(rw, err.Error(), 500)
+			return
+		}
+		rw.WriteHeader(200)
+		fmt.Fprintf(rw, "user=%s", session.User)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: testCookieName, Value: vec.CookieValue})
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	if string(body) != "user=bob" {
+		t.Fatalf("body = %q, want %q", string(body), "user=bob")
+	}
+
+	cookies := resp.Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 cookie, got %d", len(cookies))
+	}
+
+	if !strings.HasPrefix(cookies[0].Value, versionPrefix) {
+		t.Fatalf("cookie %q missing sc1_ prefix", cookies[0].Value)
+	}
+}
+
+func TestMigrationConvertError(t *testing.T) {
+	vectors := loadVectors(t)
+	vec := vectors[0]
+
+	goKey := createKeyString()
+
+	config := &Config{
+		CookieName: testCookieName,
+		HTTPOnly:   true,
+		Secure:     false,
+		MaxAge:     24 * time.Hour,
+	}
+
+	convert := func(jsonData []byte) (*pb.TestSession, error) {
+		return nil, fmt.Errorf("conversion failed")
+	}
+
+	mw, err := NewMiddleware[*pb.TestSession](goKey, config,
+		WithMigration[*pb.TestSession](vec.Key, convert))
+	if err != nil {
+		t.Fatalf("NewMiddleware: %v", err)
+	}
+
+	handler := mw(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		session, err := GetSession[*pb.TestSession](req.Context())
+		if err != nil {
+			http.Error(rw, err.Error(), 500)
+			return
+		}
+		rw.WriteHeader(200)
+		fmt.Fprintf(rw, "count=%d", session.Count)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: testCookieName, Value: vec.CookieValue})
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Should get empty session since convert failed
+	if string(body) != "count=0" {
+		t.Fatalf("body = %q, want %q (empty session)", string(body), "count=0")
+	}
+}
+
+func TestNoMigrationIgnoresJSCookies(t *testing.T) {
+	vectors := loadVectors(t)
+	vec := vectors[0]
+
+	goKey := createKeyString()
+
+	config := &Config{
+		CookieName: testCookieName,
+		HTTPOnly:   true,
+		Secure:     false,
+		MaxAge:     24 * time.Hour,
+	}
+
+	// No WithMigration option
+	mw, err := NewMiddleware[*pb.TestSession](goKey, config)
+	if err != nil {
+		t.Fatalf("NewMiddleware: %v", err)
+	}
+
+	handler := mw(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		session, err := GetSession[*pb.TestSession](req.Context())
+		if err != nil {
+			http.Error(rw, err.Error(), 500)
+			return
+		}
+		rw.WriteHeader(200)
+		fmt.Fprintf(rw, "count=%d", session.Count)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: testCookieName, Value: vec.CookieValue})
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Should get empty session since no migration configured
+	if string(body) != "count=0" {
+		t.Fatalf("body = %q, want %q (empty session)", string(body), "count=0")
+	}
+}

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -424,6 +424,85 @@ func TestMigrationGarbageInput(t *testing.T) {
 	}
 }
 
+// TestMigrationWithLegacyGoCookie verifies that when migration is enabled,
+// a legacy Go cookie (no sc1_ prefix, not JS format) is still decodable.
+func TestMigrationWithLegacyGoCookie(t *testing.T) {
+	goKey := createKeyString()
+
+	config := &Config{
+		CookieName: testCookieName,
+		HTTPOnly:   true,
+		Secure:     false,
+		MaxAge:     24 * time.Hour,
+	}
+
+	convert := func(jsonData []byte) (*pb.TestSession, error) {
+		return nil, fmt.Errorf("should not be called for Go cookies")
+	}
+
+	// First, create a Go cookie (with sc1_ prefix) using a handler without migration
+	mwNoMigrate, err := NewMiddleware[*pb.TestSession](goKey, config)
+	if err != nil {
+		t.Fatalf("NewMiddleware: %v", err)
+	}
+
+	setHandler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		session, _ := GetSession[*pb.TestSession](req.Context())
+		session.Count = 77
+		session.User = "legacy-with-migration"
+		SetSession(req.Context(), session)
+		rw.WriteHeader(200)
+	})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	mwNoMigrate(setHandler).ServeHTTP(w, req)
+
+	cookies := w.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 cookie, got %d", len(cookies))
+	}
+
+	// Strip sc1_ prefix to simulate a legacy Go cookie
+	legacyCookie := &http.Cookie{
+		Name:  testCookieName,
+		Value: strings.TrimPrefix(cookies[0].Value, versionPrefix),
+	}
+
+	// Now create a handler WITH migration enabled and send the legacy Go cookie
+	mwWithMigrate, err := NewMiddleware[*pb.TestSession](goKey, config,
+		WithMigration[*pb.TestSession]("some-js-key", convert))
+	if err != nil {
+		t.Fatalf("NewMiddleware: %v", err)
+	}
+
+	readHandler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		session, err := GetSession[*pb.TestSession](req.Context())
+		if err != nil {
+			http.Error(rw, err.Error(), 500)
+			return
+		}
+		rw.WriteHeader(200)
+		fmt.Fprintf(rw, "count=%d user=%s", session.Count, session.User)
+	})
+
+	req = httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(legacyCookie)
+	w = httptest.NewRecorder()
+	mwWithMigrate(readHandler).ServeHTTP(w, req)
+
+	resp := w.Result()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	if string(body) != "count=77 user=legacy-with-migration" {
+		t.Fatalf("body = %q, want %q", string(body), "count=77 user=legacy-with-migration")
+	}
+}
+
 func TestNoMigrationIgnoresJSCookies(t *testing.T) {
 	vectors := loadVectors(t)
 	vec := vectors[0]

--- a/seshcookie.go
+++ b/seshcookie.go
@@ -495,11 +495,11 @@ func (h *Handler[T]) getCookieSession(req *http.Request) (T, []byte, *timestampp
 	// No prefix: try JS migration if configured
 	if h.opts.migrate != nil {
 		session, err := h.decodeJSSession(value)
-		if err != nil {
-			return zero, nil, nil
+		if err == nil {
+			// nil hash so writeCookie always rewrites as Go format
+			return session, nil, nil
 		}
-		// nil hash so writeCookie always rewrites as Go format
-		return session, nil, nil
+		// JS decode failed; fall through to legacy Go decode
 	}
 
 	// Legacy Go-format cookie (pre-sc1_ version): attempt decode

--- a/seshcookie.go
+++ b/seshcookie.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -37,6 +38,10 @@ const (
 )
 
 const defaultCookieName = "session"
+
+// versionPrefix is prepended to all Go-format cookies for
+// unambiguous format detection during JS migration.
+const versionPrefix = "sc1_"
 
 var (
 	// DefaultConfig is used as the configuration if a nil config
@@ -153,6 +158,7 @@ type Handler[T proto.Message] struct {
 	http.Handler
 	Config Config
 	encKey []byte
+	opts   handlerOptions[T]
 }
 
 // GetSession retrieves the session from the context.
@@ -324,7 +330,7 @@ func encodeCookie[T proto.Message](session T, encKey []byte, maxAge time.Duratio
 
 	ciphertext := aeadCipher.Seal(nonce, nonce, plaintext, nil)
 
-	return base64.StdEncoding.EncodeToString(ciphertext), protoHash.Sum(nil), nil
+	return versionPrefix + base64.StdEncoding.EncodeToString(ciphertext), protoHash.Sum(nil), nil
 }
 
 // decodeCookie decrypts a base64-encoded cookie using AES-GCM for
@@ -332,6 +338,8 @@ func encodeCookie[T proto.Message](session T, encKey []byte, maxAge time.Duratio
 // Returns the session, hash, and original issuedAt timestamp.
 func decodeCookie[T proto.Message](encoded string, encKey []byte, maxAge time.Duration) (T, []byte, *timestamppb.Timestamp, error) {
 	var zero T
+
+	encoded = strings.TrimPrefix(encoded, versionPrefix)
 
 	cookie, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
@@ -474,17 +482,29 @@ func (h *Handler[T]) getCookieSession(req *http.Request) (T, []byte, *timestampp
 		return zero, nil, nil
 	}
 
-	session, protoHash, issuedAt, err := decodeCookie[T](cookie.Value, h.encKey, h.Config.MaxAge)
-	if err != nil {
-		// Invalid cookie or expired session - treat as no session
-		// Log for debugging but don't expose to user
-		if errors.Is(err, ErrSessionExpired) {
-			// Silently ignore expired sessions
+	value := cookie.Value
+
+	if strings.HasPrefix(value, versionPrefix) {
+		// Go-format cookie: strip prefix and decode
+		value = strings.TrimPrefix(value, versionPrefix)
+		session, protoHash, issuedAt, err := decodeCookie[T](value, h.encKey, h.Config.MaxAge)
+		if err != nil {
+			return zero, nil, nil
 		}
-		return zero, nil, nil
+		return session, protoHash, issuedAt
 	}
 
-	return session, protoHash, issuedAt
+	// No prefix: try JS migration if configured
+	if h.opts.migrate != nil {
+		session, err := h.decodeJSSession(value)
+		if err != nil {
+			return zero, nil, nil
+		}
+		// Return with nil hash so writeCookie always rewrites as Go format
+		return session, nil, nil
+	}
+
+	return zero, nil, nil
 }
 
 func (h *Handler[T]) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
@@ -523,7 +543,7 @@ func (h *Handler[T]) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 //	}
 //
 //	http.Handle("/", mw(http.HandlerFunc(myHandler))
-func NewMiddleware[T proto.Message](key string, config *Config) (func(http.Handler) http.Handler, error) {
+func NewMiddleware[T proto.Message](key string, config *Config, opts ...Option[T]) (func(http.Handler) http.Handler, error) {
 	if key == "" {
 		return nil, errors.New("encryption key must not be empty")
 	}
@@ -548,11 +568,17 @@ func NewMiddleware[T proto.Message](key string, config *Config) (func(http.Handl
 		config.MaxAge = DefaultConfig.MaxAge
 	}
 
+	var options handlerOptions[T]
+	for _, o := range opts {
+		o(&options)
+	}
+
 	return func(next http.Handler) http.Handler {
 		return &Handler[T]{
 			Handler: next,
 			Config:  *config,
 			encKey:  encKey,
+			opts:    options,
 		}
 	}, nil
 }
@@ -572,7 +598,7 @@ func NewMiddleware[T proto.Message](key string, config *Config) (func(http.Handl
 //	}
 //
 //	http.ListenAndServe(":8080", handler)
-func NewHandler[T proto.Message](handler http.Handler, key string, config *Config) (*Handler[T], error) {
+func NewHandler[T proto.Message](handler http.Handler, key string, config *Config, opts ...Option[T]) (*Handler[T], error) {
 	if key == "" {
 		return nil, errors.New("encryption key must not be empty")
 	}
@@ -597,9 +623,15 @@ func NewHandler[T proto.Message](handler http.Handler, key string, config *Confi
 		config.MaxAge = DefaultConfig.MaxAge
 	}
 
+	var options handlerOptions[T]
+	for _, o := range opts {
+		o(&options)
+	}
+
 	return &Handler[T]{
 		Handler: handler,
 		Config:  *config,
 		encKey:  encKey,
+		opts:    options,
 	}, nil
 }

--- a/seshcookie.go
+++ b/seshcookie.go
@@ -485,8 +485,6 @@ func (h *Handler[T]) getCookieSession(req *http.Request) (T, []byte, *timestampp
 	value := cookie.Value
 
 	if strings.HasPrefix(value, versionPrefix) {
-		// Go-format cookie: strip prefix and decode
-		value = strings.TrimPrefix(value, versionPrefix)
 		session, protoHash, issuedAt, err := decodeCookie[T](value, h.encKey, h.Config.MaxAge)
 		if err != nil {
 			return zero, nil, nil
@@ -500,11 +498,17 @@ func (h *Handler[T]) getCookieSession(req *http.Request) (T, []byte, *timestampp
 		if err != nil {
 			return zero, nil, nil
 		}
-		// Return with nil hash so writeCookie always rewrites as Go format
+		// nil hash so writeCookie always rewrites as Go format
 		return session, nil, nil
 	}
 
-	return zero, nil, nil
+	// Legacy Go-format cookie (pre-sc1_ version): attempt decode
+	session, _, issuedAt, err := decodeCookie[T](value, h.encKey, h.Config.MaxAge)
+	if err != nil {
+		return zero, nil, nil
+	}
+	// nil hash so writeCookie rewrites with sc1_ prefix
+	return session, nil, issuedAt
 }
 
 func (h *Handler[T]) ServeHTTP(rw http.ResponseWriter, req *http.Request) {

--- a/seshcookie_test.go
+++ b/seshcookie_test.go
@@ -665,6 +665,36 @@ func TestReaderFromProxying(t *testing.T) {
 	})
 }
 
+// TestVersionPrefix tests that encoded cookies have the sc1_ prefix and roundtrip correctly
+func TestVersionPrefix(t *testing.T) {
+	encKey := createKey()
+	maxAge := 24 * time.Hour
+
+	orig := &pb.TestSession{
+		Count: 7,
+		User:  "prefix-test",
+	}
+
+	encoded, _, err := encodeCookie(orig, encKey, maxAge, nil)
+	if err != nil {
+		t.Fatalf("encodeCookie: %v", err)
+	}
+
+	if !strings.HasPrefix(encoded, versionPrefix) {
+		t.Errorf("encoded cookie %q does not start with %q", encoded, versionPrefix)
+	}
+
+	decoded, _, _, err := decodeCookie[*pb.TestSession](encoded, encKey, maxAge)
+	if err != nil {
+		t.Fatalf("decodeCookie: %v", err)
+	}
+
+	if decoded.Count != orig.Count || decoded.User != orig.User {
+		t.Errorf("roundtrip mismatch: got {%d, %s}, want {%d, %s}",
+			decoded.Count, decoded.User, orig.Count, orig.User)
+	}
+}
+
 // TestSessionChangeDetection tests that unchanged sessions aren't re-written
 func TestSessionChangeDetection(t *testing.T) {
 	key := createKeyString()

--- a/seshcookie_test.go
+++ b/seshcookie_test.go
@@ -695,6 +695,84 @@ func TestVersionPrefix(t *testing.T) {
 	}
 }
 
+// TestLegacyGoCookieWithoutPrefix tests that cookies encoded by
+// pre-sc1_ versions of seshcookie are still readable after upgrade.
+func TestLegacyGoCookieWithoutPrefix(t *testing.T) {
+	key := createKeyString()
+	config := &Config{
+		CookieName: testCookieName,
+		HTTPOnly:   true,
+		Secure:     false,
+		MaxAge:     24 * time.Hour,
+	}
+
+	// Create a handler, set a session, capture the Go cookie
+	mw, err := NewMiddleware[*pb.TestSession](key, config)
+	if err != nil {
+		t.Fatalf("NewMiddleware: %v", err)
+	}
+
+	setHandler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		session, _ := GetSession[*pb.TestSession](req.Context())
+		session.Count = 99
+		session.User = "legacy"
+		SetSession(req.Context(), session)
+		rw.WriteHeader(200)
+	})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	mw(setHandler).ServeHTTP(w, req)
+
+	cookies := w.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 cookie, got %d", len(cookies))
+	}
+
+	goCookie := cookies[0]
+	if !strings.HasPrefix(goCookie.Value, versionPrefix) {
+		t.Fatalf("expected sc1_ prefix on cookie")
+	}
+
+	// Simulate a legacy cookie by stripping the sc1_ prefix
+	legacyCookie := &http.Cookie{
+		Name:  testCookieName,
+		Value: strings.TrimPrefix(goCookie.Value, versionPrefix),
+	}
+
+	// Send it to a fresh handler without migration - should still decode
+	readHandler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		session, err := GetSession[*pb.TestSession](req.Context())
+		if err != nil {
+			http.Error(rw, err.Error(), 500)
+			return
+		}
+		rw.WriteHeader(200)
+		fmt.Fprintf(rw, "count=%d user=%s", session.Count, session.User)
+	})
+
+	req = httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(legacyCookie)
+	w = httptest.NewRecorder()
+
+	mw, err = NewMiddleware[*pb.TestSession](key, config)
+	if err != nil {
+		t.Fatalf("NewMiddleware: %v", err)
+	}
+	mw(readHandler).ServeHTTP(w, req)
+
+	resp := w.Result()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	if string(body) != "count=99 user=legacy" {
+		t.Fatalf("body = %q, want %q", string(body), "count=99 user=legacy")
+	}
+}
+
 // TestSessionChangeDetection tests that unchanged sessions aren't re-written
 func TestSessionChangeDetection(t *testing.T) {
 	key := createKeyString()

--- a/testdata/js_vectors.json
+++ b/testdata/js_vectors.json
@@ -1,0 +1,32 @@
+{
+  "vectors": [
+    {
+      "description": "simple session",
+      "key": "test-secret-key",
+      "derived_key_hex": "2ceac6f36363c6246a64cca805cd43ca",
+      "session_json": "{\"count\":42,\"user\":\"alice\"}",
+      "cookie_value": "3aa+aXz569GDmpKf-IWlwpFpnMTSYlkpl/yDmNibQGx1YibFd6HJJ-DRzIWfGM+/+MN3hJMRIYFw=="
+    },
+    {
+      "description": "single string field",
+      "key": "another-key-here",
+      "derived_key_hex": "b279b47a71470f669a4e0135e8282b5d",
+      "session_json": "{\"name\":\"bob\"}",
+      "cookie_value": "fOxSUbi6kDmqSYzW-5qHkcg3FaPkCNxtNPcM=-Q8kBpP7/iPb4vKfmujGyIg=="
+    },
+    {
+      "description": "nested object with arrays",
+      "key": "test-secret-key",
+      "derived_key_hex": "2ceac6f36363c6246a64cca805cd43ca",
+      "session_json": "{\"user\":{\"id\":1,\"name\":\"charlie\",\"roles\":[\"admin\",\"editor\"]},\"metadata\":{\"created\":\"2025-01-01\",\"tags\":[\"important\",\"reviewed\"]}}",
+      "cookie_value": "jeYobrUmpTOmF/mP-P2chHQUCNIEDPYeByYHFSm3Z1fPVgEq3g0pVg8jo4T5yx6/6hZZxoylv+ElAqOY67rp7/qVvLvuOydWCOLYD72hBooAe6G0zq943oYHujvOK5j0XLs2Ru52G/z3Id9PkLcO3pzsAwy58bazDb+rPmuqntRXw7uVLZQIOkws+fdp1-GRNIFkqvfjSWEWExjBpx2Q=="
+    },
+    {
+      "description": "unicode content",
+      "key": "unicode-key-test",
+      "derived_key_hex": "b5a9411b8786ccbecab58eaaa8d79437",
+      "session_json": "{\"greeting\":\"你好世界\",\"emoji\":\"🌟🌈\",\"name\":\"René\"}",
+      "cookie_value": "zaionMRbswrbu0QD-FIYLvk+PPy3s/hoUKrGA7XTcLLtymxDQOTduKCT2YjrWpuenUfOmOiit7t4dZoxeAUB5zxXWGlfFpw26pw==-7soksjLXBsekSG6AOQOcKA=="
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add migration support for decrypting cookies created by the JavaScript seshcookie library, enabling seamless Go migration
- Introduce `sc1_` wire format prefix to distinguish Go-encoded cookies from JS-encoded ones
- JS seshcookie uses SHA256(key)[:16] for KDF and a `b64(nonce)-b64(ct)-b64(tag)` wire format with nonce as AAD; the Go format uses `sc1_` + base64(nonce || ciphertext || tag) with nil AAD
- Add `WithMigration` functional option to enable transparent reading of JS cookies while always writing in the new Go format
- Golden test vectors generated from the actual JS implementation ensure cross-implementation compatibility

## Test plan

- [x] Unit tests for JS wire format decryption with golden test vectors
- [x] Tests for `sc1_` prefix handling (presence and absence)
- [x] Round-trip tests for Go format encode/decode
- [x] Migration handler HTTP tests verifying transparent session upgrade
- [x] Expiry validation tests